### PR TITLE
Added install instruction using pip3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # PyTorch-ARM-Builds
 LIst of torch arm builds. Mostly raspberry pi
+
+# Install
+Here's how to install with `pip3`
+
+```
+sudo pip3 install https://github.com/isakbosman/pytorch_arm_builds/raw/main/<file.whl>
+```
+
+Added because plain link to github file won't work (because it presents an HTTP page, rather than the raw file).


### PR DESCRIPTION
Hi Isakbosman,

Added installation instructions.

Just so that others don't go through the same trouble as me trying to install directly (in my ignorance 😭 ). For me `pip3` was constantly reporting that the file is not a zip file, when the issue was that I stuck the "regular URL" of the file, and not the raw url.